### PR TITLE
Fix/gamedig

### DIFF
--- a/lgsm/functions/query_gamedig.sh
+++ b/lgsm/functions/query_gamedig.sh
@@ -30,7 +30,7 @@ if [ "$(command -v gamedig 2>/dev/null)" ]&&[ "$(command -v jq 2>/dev/null)" ]; 
 		fi
 
 		# numplayers.
-		gdplayers=$(echo -e "${gamedigraw}" | jq -re '.players')
+		gdplayers=$(echo -e "${gamedigraw}" | jq -re '.raw.vanilla.raw.players.online')
 		if [ "${gdplayers}" == "null" ]; then
 			unset gdplayers
 		elif [ "${gdplayers}" == "[]" ]; then


### PR DESCRIPTION
# Description

Found that when running the monitor and gamedig, the output for the server player count was showing the wrong output from gamedig. Altering the "gdplayers" variable to look further into the JSON tree found the correct value.

Fixes #2647

## Type of change

* [x] Bug fix (change which fixes an issue).
* [ ] New feature (change which adds functionality).
* [ ] New Server (new server added).
* [ ] Refactor (restructures existing code).
* [ ] Comment update (typo, spelling, explanation, examples, etc).

## Checklist

PR will not be merged until all steps are complete.

* [x] This pull request links to an issue.
* [x] This pull request uses the `develop` branch as its base.
* [x] This pull request Subject follows the Conventional Commits standard.
* [x] This code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have checked that this code is commented where required.
* [x] I have provided a detailed enough description of this PR.
* [x] I have checked If documentation needs updating.

**Thank you for your Pull Request!**
